### PR TITLE
Add Windows ARM support

### DIFF
--- a/.github/workflows/build-tdlib.yml
+++ b/.github/workflows/build-tdlib.yml
@@ -93,14 +93,20 @@ jobs:
           overwrite: true
 
   build-windows:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+          - os: windows-11-arm
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Restore cache TDLib
         id: cache-tdlib-restore
         uses: actions/cache/restore@v4
         with:
           path: td/
-          key: tdlib-${{ env.TDLIB_VERSION }}-windows-x86_64
+          key: tdlib-${{ env.TDLIB_VERSION }}-windows-${{ runner.arch == 'ARM64' && 'aarch64' || 'x86_64' }}
       - name: Build TDLib
         if: steps.cache-tdlib-restore.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build-tdlib.yml
+++ b/.github/workflows/build-tdlib.yml
@@ -117,12 +117,21 @@ jobs:
           cd vcpkg
           git checkout 07b30b49e5136a36100a2ce644476e60d7f3ddc1
           ./bootstrap-vcpkg.bat
-          ./vcpkg.exe install gperf:x64-windows openssl:x64-windows zlib:x64-windows
+          if [[ "$RUNNER_ARCH" == "X64" ]]; then
+            ./vcpkg.exe install gperf:x64-windows openssl:x64-windows zlib:x64-windows
+            CMAKE_ARCH="x64"
+          elif [[ "$RUNNER_ARCH" == "ARM64" ]]; then
+            ./vcpkg.exe install gperf:arm64-windows openssl:arm64-windows zlib:arm64-windows
+            CMAKE_ARCH="ARM64"
+          else
+            echo "Unsupported architecture: $RUNNER_ARCH"
+            exit 1
+          fi
           cd ..
           rm -rf build
           mkdir build
           cd build
-          cmake -A x64 -DCMAKE_INSTALL_PREFIX:PATH=../tdlib -DCMAKE_TOOLCHAIN_FILE:FILEPATH=../vcpkg/scripts/buildsystems/vcpkg.cmake ..
+          cmake -A "$CMAKE_ARCH" -DCMAKE_INSTALL_PREFIX:PATH=../tdlib -DCMAKE_TOOLCHAIN_FILE:FILEPATH=../vcpkg/scripts/buildsystems/vcpkg.cmake ..
           cmake --build . --target install --config Release
         shell: bash
       - name: Save cache TDLib

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Create release
         run: gh release create ${{ github.ref_name }} -R $REPO --generate-notes ./*.zip
 
-  release_crates:
-    runs-on: ubuntu-latest
-    needs: release_github
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Publish to crates.io
-        run: |
-          cargo login ${{ secrets.CRATES_IO_TOKEN }}
-          cargo publish --package tdlib-rs-parser
-          cargo publish --package tdlib-rs-gen
-          cargo publish --no-verify --package tdlib-rs
+  # release_crates:
+  #   runs-on: ubuntu-latest
+  #   needs: release_github
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Publish to crates.io
+  #       run: |
+  #         cargo login ${{ secrets.CRATES_IO_TOKEN }}
+  #         cargo publish --package tdlib-rs-parser
+  #         cargo publish --package tdlib-rs-gen
+  #         cargo publish --no-verify --package tdlib-rs

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Create release
         run: gh release create ${{ github.ref_name }} -R $REPO --generate-notes ./*.zip
 
-  # release_crates:
-  #   runs-on: ubuntu-latest
-  #   needs: release_github
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: Publish to crates.io
-  #       run: |
-  #         cargo login ${{ secrets.CRATES_IO_TOKEN }}
-  #         cargo publish --package tdlib-rs-parser
-  #         cargo publish --package tdlib-rs-gen
-  #         cargo publish --no-verify --package tdlib-rs
+  release_crates:
+    runs-on: ubuntu-latest
+    needs: release_github
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Publish to crates.io
+        run: |
+          cargo login ${{ secrets.CRATES_IO_TOKEN }}
+          cargo publish --package tdlib-rs-parser
+          cargo publish --package tdlib-rs-gen
+          cargo publish --no-verify --package tdlib-rs

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [local-tdlib, download-tdlib, pkg-config, docs]
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        feature: [local-tdlib, download-tdlib, pkg-config, docs]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust
         if: runner.arch == 'ARM64'
-        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1.12.0
         with:
           target: aarch64-pc-windows-msvc
           components: clippy, rustfmt

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [local-tdlib, download-tdlib, pkg-config, docs]
         os: [windows-latest, windows-11-arm]
+        feature: [local-tdlib, download-tdlib, pkg-config, docs]
 
     runs-on: ${{ matrix.os }}
 
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        if: runner.arch == 'ARM64'
+        if: matrix.os == 'windows-11-arm'
         uses: actions-rust-lang/setup-rust-toolchain@v1.12.0
         with:
           target: aarch64-pc-windows-msvc

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -36,7 +36,7 @@ jobs:
         if: runner.arch == 'ARM64'
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
-          target: x86_64-pc-windows-msvc
+          target: aarch64-pc-windows-msvc
           components: clippy, rustfmt
       - name: Download TDLib
         if:  matrix.feature == 'local-tdlib' || matrix.feature == 'pkg-config'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Rust
+        if: runner.arch == 'ARM64'
+        uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
       - name: Download TDLib
         if:  matrix.feature == 'local-tdlib' || matrix.feature == 'pkg-config'
         run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -25,8 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         feature: [local-tdlib, download-tdlib, pkg-config, docs]
+        os: [windows-latest, windows-11-arm]
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -34,7 +35,7 @@ jobs:
       - name: Download TDLib
         if:  matrix.feature == 'local-tdlib' || matrix.feature == 'pkg-config'
         run: |
-          gh release download --pattern 'tdlib-*-windows-x86_64.zip'
+          gh release download --pattern ${{ runner.arch == 'ARM64' && 'tdlib-*-windows-aarch64.zip' || 'tdlib-*-windows-x86_64.zip' }}
           unzip -q *.zip -d .
         shell: bash
       - name: Install pkg-config

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install Rust
         if: runner.arch == 'ARM64'
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
+        with:
+          target: x86_64-pc-windows-msvc
+          components: clippy, rustfmt
       - name: Download TDLib
         if:  matrix.feature == 'local-tdlib' || matrix.feature == 'pkg-config'
         run: |

--- a/tdlib-rs/build.rs
+++ b/tdlib-rs/build.rs
@@ -75,6 +75,7 @@ fn copy_local_tdlib() {
 /// - Linux x86_64
 /// - Linux aarch64
 /// - Windows x86_64
+/// - Windows aarch64
 /// - MacOS x86_64
 /// - MacOS aarch64
 fn generic_build() {
@@ -97,7 +98,10 @@ fn generic_build() {
         {
             format!("{}/libtdjson.{}.dylib", lib_dir, TDLIB_VERSION)
         }
-        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        #[cfg(any(
+            all(target_os = "windows", target_arch = "x86_64"),
+            all(target_os = "windows", target_arch = "aarch64")
+        ))]
         {
             format!(r"{}\tdjson.lib", lib_dir)
         }
@@ -107,7 +111,10 @@ fn generic_build() {
         panic!("tdjson shared library not found at {}", lib_path);
     }
 
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64")
+    ))]
     {
         let bin_dir = format!(r"{}\bin", prefix);
         println!("cargo:rustc-link-search=native={}", bin_dir);

--- a/tdlib-rs/build.rs
+++ b/tdlib-rs/build.rs
@@ -128,7 +128,7 @@ fn generic_build() {
 
 #[cfg(feature = "download-tdlib")]
 fn download_tdlib() {
-    let base_url = "https://github.com/FedericoBruzzone/tdlib-rs/releases/download";
+    let base_url = "https://github.com/Andreal2000/tdlib-rs/releases/download";
     let url = format!(
         "{}/v{}/tdlib-{}-{}-{}.zip",
         base_url,

--- a/tdlib-rs/build.rs
+++ b/tdlib-rs/build.rs
@@ -128,7 +128,7 @@ fn generic_build() {
 
 #[cfg(feature = "download-tdlib")]
 fn download_tdlib() {
-    let base_url = "https://github.com/Andreal2000/tdlib-rs/releases/download";
+    let base_url = "https://github.com/FedericoBruzzone/tdlib-rs/releases/download";
     let url = format!(
         "{}/v{}/tdlib-{}-{}-{}.zip",
         base_url,

--- a/tdlib-rs/src/build.rs
+++ b/tdlib-rs/src/build.rs
@@ -61,7 +61,7 @@ fn copy_dir_all(
 ///
 /// If the OS or architecture is not supported, the function will panic.
 fn download_tdlib() {
-    let base_url = "https://github.com/Andreal2000/tdlib-rs/releases/download";
+    let base_url = "https://github.com/FedericoBruzzone/tdlib-rs/releases/download";
     let url = format!(
         "{}/v{}/tdlib-{}-{}-{}.zip",
         base_url,

--- a/tdlib-rs/src/build.rs
+++ b/tdlib-rs/src/build.rs
@@ -61,7 +61,7 @@ fn copy_dir_all(
 ///
 /// If the OS or architecture is not supported, the function will panic.
 fn download_tdlib() {
-    let base_url = "https://github.com/FedericoBruzzone/tdlib-rs/releases/download";
+    let base_url = "https://github.com/Andreal2000/tdlib-rs/releases/download";
     let url = format!(
         "{}/v{}/tdlib-{}-{}-{}.zip",
         base_url,

--- a/tdlib-rs/src/build.rs
+++ b/tdlib-rs/src/build.rs
@@ -53,7 +53,9 @@ fn copy_dir_all(
 /// The OUT_DIR environment variable is set by Cargo and points to the target directory.
 /// The OS and architecture currently supported are:
 /// - Linux x86_64
+/// - Linux aarch64
 /// - Windows x86_64
+/// - Windows aarch64
 /// - MacOS x86_64
 /// - MacOS aarch64
 ///
@@ -135,7 +137,7 @@ fn download_tdlib() {
 /// - `cargo:include=.../tdlib/include`
 /// - `cargo:rustc-link-lib=dylib=tdjson`
 /// - `cargo:rustc-link-arg=-Wl,-rpath,.../tdlib/lib`
-/// - `cargo:rustc-link-search=native=.../tdlib/bin` (only for Windows x86_64)
+/// - `cargo:rustc-link-search=native=.../tdlib/bin` (only for Windows)
 ///
 /// The `...` represents the `dest_path` or the `OUT_DIR` environment variable.
 ///
@@ -174,7 +176,10 @@ fn generic_build(lib_path: Option<String>) {
         {
             format!("{}/libtdjson.{}.dylib", lib_dir, TDLIB_VERSION)
         }
-        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        #[cfg(any(
+            all(target_os = "windows", target_arch = "x86_64"),
+            all(target_os = "windows", target_arch = "aarch64")
+        ))]
         {
             format!(r"{}\tdjson.lib", lib_dir)
         }
@@ -188,7 +193,10 @@ fn generic_build(lib_path: Option<String>) {
     // tdjson.dll using the commands below.
     // TODO: investigate and if it is a bug in `cargo` or `rustc`, open an issue to `cargo` to fix
     // this.
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64")
+    ))]
     {
         let bin_dir = format!(r"{}\bin", prefix);
         let cargo_bin = format!("{}/.cargo/bin", dirs::home_dir().unwrap().to_str().unwrap());
@@ -216,7 +224,10 @@ fn generic_build(lib_path: Option<String>) {
         let _ = std::fs::copy(zlib1.clone(), cargo_zlib1.clone());
     }
 
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64")
+    ))]
     {
         let bin_dir = format!(r"{}\bin", prefix);
         println!("cargo:rustc-link-search=native={}", bin_dir);
@@ -334,7 +345,7 @@ pub fn build_pkg_config() {
 /// - `cargo:include=.../tdlib/include`
 /// - `cargo:rustc-link-lib=dylib=tdjson`
 /// - `cargo:rustc-link-arg=-Wl,-rpath,.../tdlib/lib`
-/// - `cargo:rustc-link-search=native=.../tdlib/bin` (only for Windows x86_64)
+/// - `cargo:rustc-link-search=native=.../tdlib/bin` (only for Windows)
 ///
 /// The `...` represents the `dest_path` or the `OUT_DIR` environment variable.
 ///
@@ -342,7 +353,9 @@ pub fn build_pkg_config() {
 /// Using the `download-tdlib` feature, no system dependencies are required.
 /// The OS and architecture currently supported are:
 /// - Linux x86_64
+/// - Linux aarch64
 /// - Windows x86_64
+/// - Windows aarch64
 /// - MacOS x86_64
 /// - MacOS aarch64
 ///
@@ -400,7 +413,7 @@ pub fn build_download_tdlib(dest_path: Option<String>) {
 /// - `cargo:include=.../tdlib/include`
 /// - `cargo:rustc-link-lib=dylib=tdjson`
 /// - `cargo:rustc-link-arg=-Wl,-rpath,.../tdlib/lib`
-/// - `cargo:rustc-link-search=native=.../tdlib/bin` (only for Windows x86_64)
+/// - `cargo:rustc-link-search=native=.../tdlib/bin` (only for Windows)
 ///
 /// The `...` represents the `LOCAL_TDLIB_PATH` environment variable.
 ///


### PR DESCRIPTION
The CI will fail until the new release.
When the Windows ARM runner will have Rust installed by default we will need to update the CI.